### PR TITLE
Explicitly mark comments

### DIFF
--- a/tracks
+++ b/tracks
@@ -26,4 +26,4 @@ OutputFile: HTTYD with OST.mkv
 022 1:24:09
 023 1:26:58
 ;-1:29:00
-Shine-through
+; Shine-through


### PR DESCRIPTION
An upcoming change to FrozenOST will make comment markers essential - implicit comments will become errors. Adding explicit semicolons to comments is completely backward compatible and will allow this project to be built on both current and upcoming versions of FrozenOST.